### PR TITLE
1 check validity of caseinsensitivestringinputgetter with specified arguments

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -1,1 +1,1 @@
-VERSION = 1.0.0
+VERSION = "1.1.0"

--- a/src/userinputgetter/string_input_getters.py
+++ b/src/userinputgetter/string_input_getters.py
@@ -29,4 +29,4 @@ class CaseInsensitiveStringInputGetter(UserInputGetter):
         if self.supported_options is None:
             return True
 
-        return value.lower() in self.supported_options
+        return value.lower() in {x.lower() for x in self.supported_options}

--- a/tests/test_string_input_getters.py
+++ b/tests/test_string_input_getters.py
@@ -46,9 +46,11 @@ class TestCaseInsensitiveStringInputGetter:
     ):
 
         monkeypatch.setattr('builtins.input', lambda _: "FOO")
-
         assert any_case_insensitive_string_input_getter.get_input() == "FOO"
         assert specified_case_insensitive_string_input_getter.get_input() == "foo"
+
+        monkeypatch.setattr('builtins.input', lambda _: "BaZ")
+        assert specified_case_insensitive_string_input_getter.get_input() == "BAZ"
 
     def test_get_multiple_inputs(
         self,


### PR DESCRIPTION
`CaseInsensitiveStringInputGetter` had a bug in its implementation of `is_supported`, meaning all non-lowercase supported options were inaccessible. Now resolved by comparing user input lower-case to supported options lowercase